### PR TITLE
Make github credentials nullable.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,8 +83,8 @@ val sourcesJar by tasks.registering(Jar::class) {
 }
 
 version = properties["rapidVersion"] ?: "local-build"
-val githubUser: String by project
-val githubPassword: String by project
+val githubUser: String? by project
+val githubPassword: String? by project
 
 publishing {
     repositories {


### PR DESCRIPTION
This makes it possible to build the project withouth having
githubcredentials defined in the project scope.