### PR TITLE
Feature request: Publish "message contract" for an river.

### DIFF
--- a/src/main/kotlin/no/nav/helse/rapids_rivers/RapidsConnection.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/RapidsConnection.kt
@@ -33,5 +33,8 @@ abstract class RapidsConnection {
 
     interface MessageListener {
         fun onMessage(message: String, context: MessageContext)
+        fun onContracts(): List<JsonMessage.Contract> {
+            return emptyList()
+        }
     }
 }

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/River.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/River.kt
@@ -31,6 +31,12 @@ class River(rapidsConnection: RapidsConnection) : RapidsConnection.MessageListen
         }
     }
 
+    override fun onContracts(): List<JsonMessage.Contract> {
+        val placeholder = JsonMessage("{}", MessageProblems("{}"))
+        validations.forEach { runCatching { it(placeholder) } }
+        return placeholder.contracts()
+    }
+
     private fun onPacket(packet: JsonMessage, context: RapidsConnection.MessageContext) {
         listeners.forEach { it.onPacket(packet, context) }
     }


### PR DESCRIPTION
I dagpenger har vi nå 20+ (?) rivers som publiserer løsninger og vi har et behov for at de "selvdokumenterer" seg selv. Det hadde vært kult om en river(app) publiserer sin "meldingskontrakt" på oppstart for å dokumentere koblinger. En melding inneholder feks: 

```
{
  "system_read_count": 1,
  "@event_name": "documentation",
  "@opprettet": "2020-05-20T14:17:14.649234",
  "kontrakt": [
    {
      "type": "requireAll",
      "key": "@behov",
      "values": [
        "BehovNavn"
      ]
    },
    {
      "type": "requireAll",
      "key": "aProperty",
      "values": [
        "prop"
      ]
    },
    {
      "type": "interestedIn",
      "key": "aProperty",
      "values": null
    }
  ],
  "app_name": "app-name"
}


```