### PR TITLE
 Remove usage of deprecated 'set-env' in GitHub Actions as current se…

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Set release tag
         run: |
           export TAG_NAME="1.$(echo $GITHUB_SHA | cut -c1-7)"
-          echo "::set-env name=RELEASE_TAG::$TAG_NAME"
+          echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
       - name: Set changelog
         # (Escape newlines see https://github.com/actions/create-release/issues/25)
         run: |
@@ -51,7 +51,7 @@ jobs:
           text="${text//$'%'/%25}"
           text="${text//$'\n'/%0A}"
           text="${text//$'\r'/%0D}"
-          echo "::set-env name=CHANGELOG::$text"
+          echo "CHANGELOG=$text" >> $GITHUB_ENV
       - name: Create Release
         id: create_release
         uses: actions/create-release@latest


### PR DESCRIPTION
…tup blocks new builds. (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) [ci skip]