### PR TITLE
Added "demandAny(key: String, values: List<String>)" validator-featur…

### DIFF
--- a/src/main/kotlin/no/nav/helse/rapids_rivers/JsonMessage.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/JsonMessage.kt
@@ -97,6 +97,13 @@ open class JsonMessage(
         accessor(key)
     }
 
+    fun demandAny(key: String, values: List<String>) {
+        val node = node(key)
+        if (node.isMissingNode) return problems.error("Missing demanded key $key")
+        if (!node.isTextual || node.asText() !in values) return problems.severe("Demanded $key must be one of $values")
+        accessor(key)
+    }
+
     fun demandAllOrAny(key: String, values: List<String>) {
         val node = node(key)
         if (node.isMissingNode) problems.severe("Missing demanded key $key")

--- a/src/test/kotlin/no/nav/helse/rapids_rivers/JsonMessageTest.kt
+++ b/src/test/kotlin/no/nav/helse/rapids_rivers/JsonMessageTest.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.*
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -495,6 +496,25 @@ internal class JsonMessageTest {
                     demandAll("foo", listOf("bar", "baz"))
                     assertFalse(problems.hasErrors())
                 }
+            }
+        }
+    }
+
+    @Test
+    fun demandValueOneOf() {
+        "{\"foo\": \"bar\" }".also { json ->
+            message(json).also {
+                assertThrows(MessageProblems.MessageException::class.java) {
+                    it.demandAny("foo", listOf("foo"))
+                }
+                assertThrows<IllegalArgumentException> { it["foo"] }
+            }
+            message(json).also {
+                assertDoesNotThrow {
+                    it.demandAny("foo", listOf("bar", "foobar"))
+                }
+                assertFalse(problems.hasErrors()) { "did not expect errors: $problems" }
+                assertDoesNotThrow { it["foo"] }
             }
         }
     }


### PR DESCRIPTION
Added "demandAny(key: String, values: List<String>)" validator-feature to JsonMessage for rivers that eg. have multiple similar events with different demanded "event name" and similar require keys.

Today we solve this case by using two River-definitions that register the same implementor class with the onPaclet()-method. This would allow us to use demandAny(...) instead. API closely resembles requireAny().