### PR TITLE
Tilgjengeligjøre kafkaBaseConfig

### DIFF
--- a/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaConfig.kt
@@ -59,7 +59,7 @@ class KafkaConfig(
         put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1")
     }
 
-    private fun kafkaBaseConfig() = Properties().apply {
+    internal fun kafkaBaseConfig() = Properties().apply {
 
         if(keystoreLocation.isNullOrBlank() || keystorePassword.isNullOrBlank()){
             put(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/RapidApplication.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/RapidApplication.kt
@@ -172,8 +172,9 @@ class RapidApplication internal constructor(
         internal val rapidTopic: String,
         internal val extraTopics: List<String> = emptyList(),
         internal val kafkaConfig: KafkaConfig,
-        internal val httpPort: Int = 8080
-    ) {
+        internal val httpPort: Int = 8080) {
+        val kafkaBaseConfig = kafkaConfig.kafkaBaseConfig()
+
         companion object {
             fun fromEnv(env: Map<String, String>) = generateInstanceId(env).let { instanceId ->
                 RapidApplicationConfig(


### PR DESCRIPTION
Driver å migrerer noen apper til aiven, noen har en producer utenom den som brukes som en del av rapiden, så hadde vært kjekt å kunne få `kafkaBaseConfig` tilgjengeliggjort for å unngå i duplisere logikken med aiven/onprem.

`producerConfig` og `consumerConfig` her tenker jeg er spesifikt konfigurert for rapiden, så er kun `kafkaBaseConfig` som blir tilgjengeliggjort.