### PR TITLE
Gå over til "semver" (stigende tall) for versjonere biblioteket. Vi h…

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set release tag
         run: |
-          export TAG_NAME="$(TZ="Europe/Oslo" date +%Y%m%d%H%M).$(echo $GITHUB_SHA | cut -c 1-12)"
+          export TAG_NAME="$(TZ="Europe/Oslo" date +%Y%m%d%H%M%s).$(echo $GITHUB_SHA | cut -c 1-12)"
           echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
       - name: Set changelog
         id: changelog

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Set release tag
         run: |
-          export TAG_NAME="$(TZ="Europe/Oslo" date +%Y.%m.%d-%H.%M).$(echo $GITHUB_SHA | cut -c 1-12)"
+          export TAG_NAME="$(TZ="Europe/Oslo" date +%Y%m%d%H%M).$(echo $GITHUB_SHA | cut -c 1-12)"
           echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
       - name: Set changelog
         id: changelog

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ Den bundlede `logback.xml` har konfigurasjon for secureLogs (men husk å enable 
 LoggerFactory.getLogger("tjenestekall")
 ```
 
+# Releasing 
+
+Alle commits på `main` gren vil lage en Github release og bygge en ny artifakt mot Jitpack. 
+
+Versjonen vil har formatet:  
+
+```YYYYmmDDMMss.<git sha>```
+
+For å "skippe" en release kan en legge til melding `[ci skip]` på git commit melding. 
+
 # Henvendelser
 
 Spørsmål knyttet til koden eller prosjektet kan stilles som issues her på GitHub.


### PR DESCRIPTION
…ar en del støtteverktøy som foreslår eldre versjoner av R&R etter commit 346b843cb03161fed67dc303bbab2ba84d9d10cb

Blant annet bruker jitpack og dependabot semver for liste å finne siste versjon, og pt lister den ut en gammel versjon av R&R. 

Eksempel er jitpack:
![Screen Shot 2022-06-07 at 10 28 47](https://user-images.githubusercontent.com/219278/172334048-35cc0c20-41f6-4094-a180-2836d93978ae.png)


Fra https://jitpack.io/#navikt/rapids-and-rivers 

![Screen Shot 2022-06-07 at 10 29 06](https://user-images.githubusercontent.com/219278/172334106-78cb0926-54b7-451c-bff4-823b071cb76c.png)


**VS** 


![Screen Shot 2022-06-07 at 10 29 21](https://user-images.githubusercontent.com/219278/172334149-83285559-1739-4315-a74b-8aee06e69d06.png)

Og dependabot https://github.com/navikt/tiltakspenger-vedtak/pull/12 som foreslår en versjon som er eldre. 

 