### PR TITLE
Api support for waiting on a producer.flush() when publishing

### DIFF
--- a/src/main/kotlin/no/nav/helse/rapids_rivers/JsonMessageContext.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/JsonMessageContext.kt
@@ -4,12 +4,12 @@ internal class JsonMessageContext(
     private val rapidsConnection: MessageContext,
     private val packet: JsonMessage
 ) : MessageContext {
-    override fun publish(message: String) {
-        rapidsConnection.publish(populateStandardFields(message))
+    override fun publish(message: String, waitForFlush: Boolean) {
+        rapidsConnection.publish(populateStandardFields(message), waitForFlush)
     }
 
-    override fun publish(key: String, message: String) {
-        rapidsConnection.publish(key, populateStandardFields(message))
+    override fun publish(key: String, message: String, waitForFlush: Boolean) {
+        rapidsConnection.publish(key, populateStandardFields(message), waitForFlush)
     }
 
     private fun populateStandardFields(message: String) =

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
@@ -64,7 +64,7 @@ class KafkaRapid(
         return rapidTopic
     }
 
-    private fun publish(producerRecord: ProducerRecord<String, String>, waitForFlush: Boolean = false) {
+    private fun publish(producerRecord: ProducerRecord<String, String>, waitForFlush: Boolean) {
         check(!producerClosed.get()) { "can't publish messages when producer is closed" }
         producer.send(producerRecord) { _, err ->
             if (err == null || !isFatalError(err)) return@send

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/KeyMessageContext.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/KeyMessageContext.kt
@@ -4,13 +4,13 @@ internal class KeyMessageContext(
     private val rapidsConnection: MessageContext,
     private val key: String?
 ) : MessageContext {
-    override fun publish(message: String) {
-        if (key == null) return rapidsConnection.publish(message)
-        publish(key, message)
+    override fun publish(message: String, waitForFlush: Boolean) {
+        if (key == null) return rapidsConnection.publish(message, waitForFlush)
+        publish(key, message, waitForFlush)
     }
 
-    override fun publish(key: String, message: String) {
-        rapidsConnection.publish(key, message)
+    override fun publish(key: String, message: String, waitForFlush: Boolean) {
+        rapidsConnection.publish(key, message, waitForFlush)
     }
 
     override fun rapidName(): String {

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/RapidApplication.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/RapidApplication.kt
@@ -56,12 +56,12 @@ class RapidApplication internal constructor(
         rapid.stop()
     }
 
-    override fun publish(message: String) {
-        rapid.publish(message)
+    override fun publish(message: String, waitForFlush: Boolean) {
+        rapid.publish(message, waitForFlush)
     }
 
-    override fun publish(key: String, message: String) {
-        rapid.publish(key, message)
+    override fun publish(key: String, message: String, waitForFlush: Boolean) {
+        rapid.publish(key, message, waitForFlush)
     }
 
     override fun rapidName(): String {

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/RapidsConnection.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/RapidsConnection.kt
@@ -3,8 +3,8 @@ package no.nav.helse.rapids_rivers
 import org.slf4j.LoggerFactory
 
 interface MessageContext {
-    fun publish(message: String)
-    fun publish(key: String, message: String)
+    fun publish(message: String, waitForFlush: Boolean = false)
+    fun publish(key: String, message: String, waitForFlush: Boolean = false)
     fun rapidName(): String
 }
 

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/testsupport/TestRapid.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/testsupport/TestRapid.kt
@@ -25,11 +25,11 @@ class TestRapid : RapidsConnection() {
         notifyMessage(message, this)
     }
 
-    override fun publish(message: String) {
+    override fun publish(message: String, waitForFlush: Boolean) {
         messages.add(null to message)
     }
 
-    override fun publish(key: String, message: String) {
+    override fun publish(key: String, message: String, waitForFlush: Boolean) {
         messages.add(key to message)
     }
 

--- a/src/test/kotlin/no/nav/helse/rapids_rivers/RiverTest.kt
+++ b/src/test/kotlin/no/nav/helse/rapids_rivers/RiverTest.kt
@@ -55,8 +55,8 @@ internal class RiverTest {
     }
 
     private val context = object : MessageContext {
-        override fun publish(message: String) {}
-        override fun publish(key: String, message: String) {}
+        override fun publish(message: String, waitForFlush: Boolean) {}
+        override fun publish(key: String, message: String, waitForFlush: Boolean) {}
         override fun rapidName(): String {return "test"}
     }
 
@@ -65,9 +65,9 @@ internal class RiverTest {
     private lateinit var messageProblems: MessageProblems
     private lateinit var river: River
     private val rapid = object : RapidsConnection() {
-        override fun publish(message: String) {}
+        override fun publish(message: String, waitForFlush: Boolean) {}
 
-        override fun publish(key: String, message: String) {}
+        override fun publish(key: String, message: String, waitForFlush: Boolean) {}
         override fun rapidName(): String {
             return "test"
         }


### PR DESCRIPTION
When publishing a packet to Kafka, you might want to wait on a producer.flush() before commiting the consumer offset of the processed packet. Not doing so may allow commiting of packet offset without produced packages being delivered to kafka due to linkerd term sequence etc.. Discussion on slack.