### PR TITLE
Move the flush til after all onRecords have been processed, so batchi…

### DIFF
--- a/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
@@ -71,9 +71,6 @@ class KafkaRapid(
             log.error("Shutting down rapid due to fatal error: ${err.message}", err)
             stop()
         }
-        if (ExperimentalFeatures.inlineFlushOnEveryProducerSend.get()) {
-            producer.flush()
-        }
     }
 
     override fun start() {
@@ -130,6 +127,9 @@ class KafkaRapid(
             currentPositions.forEach { (partition, offset) -> consumer.seek(partition, offset) }
             throw err
         } finally {
+            if (ExperimentalFeatures.inlineFlushOnEveryProducerSend.get()) {
+                producer.flush()
+            }
             consumer.commitSync(currentPositions.mapValues { (_, offset) -> offsetMetadata(offset) })
         }
     }


### PR DESCRIPTION
…ng can happen. Similar to KafkaProducer::flush example.