### PR TITLE
Ikke kall unsubscribe, da dette trigger wakeupexception og man ikke tr…

### DIFF
--- a/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
@@ -19,7 +19,7 @@ class KafkaRapid(
     consumerConfig: Properties,
     producerConfig: Properties,
     private val rapidTopic: String,
-    extraTopics: List<String> = emptyList(),
+    extraTopics: List<String> = emptyList()
 ) : RapidsConnection(), ConsumerRebalanceListener {
 
     private val log = LoggerFactory.getLogger(KafkaRapid::class.java)
@@ -121,9 +121,8 @@ class KafkaRapid(
         } catch (err: Exception) {
             log.info(
                 "due to an error during processing, positions are reset to each next message (after each record that was processed OK):" +
-                    currentPositions.map { "\tpartition=${it.key}, offset=${it.value}" }
-                        .joinToString(separator = "\n", prefix = "\n", postfix = "\n"),
-                err,
+                        currentPositions.map { "\tpartition=${it.key}, offset=${it.value}" }
+                            .joinToString(separator = "\n", prefix = "\n", postfix = "\n"), err
             )
             currentPositions.forEach { (partition, offset) -> consumer.seek(partition, offset) }
             throw err
@@ -167,7 +166,7 @@ class KafkaRapid(
     private fun pollDiganostics(records: ConsumerRecords<String, String>) = mapOf(
         "rapids_poll_id" to "${UUID.randomUUID()}",
         "rapids_poll_time" to "${LocalDateTime.now()}",
-        "rapids_poll_count" to "${records.count()}",
+        "rapids_poll_count" to "${records.count()}"
     )
 
     private fun recordDiganostics(record: ConsumerRecord<String, String>) = mapOf(
@@ -177,7 +176,7 @@ class KafkaRapid(
         "rapids_record_produced_time_type" to "${record.timestampType()}",
         "rapids_record_topic" to record.topic(),
         "rapids_record_partition" to "${record.partition()}",
-        "rapids_record_offset" to "${record.offset()}",
+        "rapids_record_offset" to "${record.offset()}"
     )
 
     private fun TopicPartition.commitSync() {
@@ -189,7 +188,6 @@ class KafkaRapid(
 
     private fun offsetMetadata(offset: Long): OffsetAndMetadata {
         val clientId = consumer.groupMetadata().groupInstanceId().map { "\"$it\"" }.orElse("null")
-
         @Language("JSON")
         val metadata = """{"time": "${LocalDateTime.now()}","groupInstanceId": $clientId}"""
         return OffsetAndMetadata(offset, metadata)
@@ -204,6 +202,7 @@ class KafkaRapid(
         producerClosed.set(true)
         tryAndLog(producer::flush)
         tryAndLog(producer::close)
+        tryAndLog(consumer::unsubscribe)
         tryAndLog(consumer::close)
     }
 
@@ -225,7 +224,7 @@ class KafkaRapid(
             consumerConfig = kafkaConfig.consumerConfig(),
             producerConfig = kafkaConfig.producerConfig(),
             rapidTopic = topic,
-            extraTopics = extraTopics,
+            extraTopics = extraTopics
         )
 
         private fun isFatalError(err: Exception) = when (err) {
@@ -233,8 +232,7 @@ class KafkaRapid(
             is RecordBatchTooLargeException,
             is RecordTooLargeException,
             is UnknownServerException,
-            is AuthorizationException,
-            -> true
+            is AuthorizationException -> true
             else -> false
         }
     }

--- a/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/KafkaRapid.kt
@@ -202,7 +202,6 @@ class KafkaRapid(
         producerClosed.set(true)
         tryAndLog(producer::flush)
         tryAndLog(producer::close)
-        tryAndLog(consumer::unsubscribe)
         tryAndLog(consumer::close)
     }
 


### PR DESCRIPTION
…enger det.

Da slipper vi å få feil der man bruker rapids&rivers slik som dette:
https://logs.adeo.no/app/discover#/doc/96e648c0-980a-11e9-830a-e17bbd64b4db/logstash-apps-prod-006204?id=Kl8odYcBqOa0yVQFlzSr

I close vil man kalle `onLeavePrepare` som igjen vil kalle `invokePartitionsRevoked` siden `LEAVE_GROUP_ON_CLOSE_CONFIG` er default satt til true og siden den er det.
Se
```
if (rebalanceConfig.leaveGroupOnClose) {
                    onLeavePrepare();
                    maybeLeaveGroup("the consumer is being closed");
                }
```
I `AbstractCoordinator`.

`client.disableWakeups();` settes i starten av close slik at man unngår en `WakeUpException`.