### PR TITLE
Forsøk på å fikse ClassCastException ved lesing av naken json.

### DIFF
--- a/src/main/kotlin/no/nav/helse/rapids_rivers/JsonMessage.kt
+++ b/src/main/kotlin/no/nav/helse/rapids_rivers/JsonMessage.kt
@@ -86,6 +86,11 @@ open class JsonMessage(
         } catch (err: JsonParseException) {
             problems.severe("Invalid JSON per Jackson library: ${err.message}")
         }
+
+        if (json !is ObjectNode) {
+            problems.severe("Incomplete json. Should be able to cast as ObjectNode.")
+        }
+
         id = json.path("@id").takeUnless { it.isMissingOrNull() }?.asText() ?: idGenerator.generateId().also {
             set("@id", it)
         }


### PR DESCRIPTION
Vi opplever propp i polling hvis et "nakent" json-objekt leses fra kafka.

For eksempel `"key": "value"` i stedet for `{"key": "value"}`.