### PR TITLE
Oppgraderer til nyaste micrometer. Merk at oppgraderinga er til simpl…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ val jvmTarget = 21
 
 val ktorVersion = "2.3.11"
 val kafkaVersion = "3.7.0"
-val micrometerRegistryPrometheusVersion = "1.12.6"
+val micrometerRegistryPrometheusVersion = "1.13.0"
 val junitJupiterVersion = "5.10.2"
 val jacksonVersion = "2.17.0"
 val logbackClassicVersion = "1.5.6"
@@ -33,7 +33,7 @@ dependencies {
     api("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
 
     api("io.ktor:ktor-server-metrics-micrometer:$ktorVersion")
-    api("io.micrometer:micrometer-registry-prometheus:$micrometerRegistryPrometheusVersion")
+    api("io.micrometer:micrometer-registry-prometheus-simpleclient:$micrometerRegistryPrometheusVersion")
 
     testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")


### PR DESCRIPTION
…eclients-versjonen. Dette er fordi den vanlege versjonen har breaking changes, som også er dårleg dokumentert i migreringsguiden.

Å bytte til simpleclients-versjonen er det dei tilrår viss du vil ha ei enkel og smertefri oppgradering, så går for det i denne omgang, og satsar på at innan det er på tide å gå bort frå den (den er jo deprecated) så er dokumentasjonen både frå micrometer-folka sjølv og andre langt betre enn det som er no.