### PR TITLE
Ta bort Git Commit SHA fra versjonsnummeret

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set release tag
         run: |
-          export TAG_NAME="$(TZ="Europe/Oslo" date +%Y%m%d%H%M%s)+$(echo $GITHUB_SHA | cut -c 1-12)"
+          export TAG_NAME="$(TZ="Europe/Oslo" date +%Y%m%d%H%M%s)"
           echo "RELEASE_TAG=$TAG_NAME" >> $GITHUB_ENV
       - uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # ratchet:ncipollo/release-action@v1
         with:


### PR DESCRIPTION
Dessverre er det ingen måte å få SHA i versjonsnummeret til å fungere ordentlig med Dependabot på.

Dependabot vil alltid ta for seg SHA'en og begynne å se etter a'er og b'er inni der, og tolke det som prereleases (alpha og beta).

Den eneste måten å unngå dette problemet på per nå er å unngå å ha SHA i versjonsnummeret i det hele tatt.