### PR TITLE
feat(observability): legg til OpenTelemetryAppender for trace-konteks…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ val micrometerRegistryPrometheusVersion = "1.16.2"
 val junitJupiterVersion = "6.0.2"
 val logbackClassicVersion = "1.5.25"
 val logbackEncoderVersion = "9.0"
+val otelLogbackVersion = "2.9.0-alpha"
 val awaitilityVersion = "4.3.0"
 val testcontainersVersion = "2.0.3"
 val jacksonVersion = "2.18.3"
@@ -29,6 +30,7 @@ dependencies {
 
     api("ch.qos.logback:logback-classic:$logbackClassicVersion")
     api("net.logstash.logback:logstash-logback-encoder:$logbackEncoderVersion")
+    api("io.opentelemetry.instrumentation:opentelemetry-logback-mdc-1.0:$otelLogbackVersion")
 
     //testImplementation("org.junit.jupiter:junit-jupiter")
     //testRuntimeOnly("org.junit.platform:junit-platform-launcher")

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -4,6 +4,10 @@
         <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
     </appender>
 
+    <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.mdc.v1_0.OpenTelemetryAppender">
+        <appender-ref ref="STDOUT_JSON" />
+    </appender>
+
     <appender name="team-logs" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
@@ -19,6 +23,6 @@
     </logger>
 
     <root level="INFO">
-        <appender-ref ref="STDOUT_JSON"/>
+        <appender-ref ref="OTEL"/>
     </root>
 </configuration>


### PR DESCRIPTION
…t i logger

   Injiserer traceId og spanId automatisk i MDC via OpenTelemetryAppender,
   som wrapper STDOUT_JSON-appenderen. LogstashEncoder plukker opp MDC-feltene
   og inkluderer dem i JSON-output.